### PR TITLE
Expose isLight and isDark functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import tinycolor from 'tinycolor2';
 import generate from './generate';
 
 export interface PalettesProps {
@@ -43,8 +44,13 @@ const purple = presetPalettes.purple;
 const magenta = presetPalettes.magenta;
 const grey = presetPalettes.grey;
 
+const isLight = (color: string): boolean => tinycolor(color).isLight();
+const isDark = (color: string): boolean => tinycolor(color).isDark();
+
 export {
   generate,
+  isLight,
+  isDark,
   presetPalettes,
   presetPrimaryColors,
   red,

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { generate, presetPalettes } from '../src';
+import { generate, isLight, isDark, yellow, purple, presetPalettes } from '../src';
 
 export const blueColors = [
   '#E6F7FF',
@@ -15,6 +15,16 @@ export const blueColors = [
 
 test('Generate palettes from a given color', () => {
   expect(generate('#1890ff')).toEqual(blueColors);
+});
+
+test('Determine the lightness of a color', () => {
+  expect(isLight(yellow[5])).toEqual(true);
+  expect(isLight(purple[5])).toEqual(false);
+});
+
+test('Determine the darkness of a color', () => {
+  expect(isDark(yellow[5])).toEqual(false);
+  expect(isDark(purple[5])).toEqual(true);
 });
 
 test('should contain preseted palettes', () => {


### PR DESCRIPTION
It is very common to overlay generated colors with text, as you do in the demo screenshot. It would be nice to determine if a generated color is light or dark to decide what color should be used for the overlaying text.

This PR exposes the `isLight` and `isDark` functions from 'tinycolor2' to make it easy to determine the lightness of a color.