### PR TITLE
Fix: added generate.d.ts file in the "files" for the dist folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lib",
     "dist/index.js",
     "dist/index.esm.js",
-    "dist/src/index.d.ts"
+    "dist/src/index.d.ts",
+    "dist/src/generate.d.ts"
   ],
   "typings": "dist/src/index.d.ts",
   "repository": {


### PR DESCRIPTION
I am migrating my project to use TypeScript and an error occurred because the "generate" file was not found in the "index" file.

![Screenshot from 2020-07-27 13-28-36](https://user-images.githubusercontent.com/1844447/88550596-bce36380-d019-11ea-872b-1913fc9aaeb3.png)

![Screenshot from 2020-07-27 14-59-32](https://user-images.githubusercontent.com/1844447/88550649-d1bff700-d019-11ea-8493-100e65e58cc7.png)

The correct thing would be to have the _@ant-design/colors/dist/src/generate.d.ts_ file. Then the file was added in "files" in order to be added to the dist.

*Versions:*
* Yarn: 1.22.4
* Node: v12.16.3
* @ant-design/colors: 4.0.4
* antd: 4.4.3

