### PR TITLE
fix: Upgrade tinycolor to 3.3.0, remove types

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "author": "afc163 <afc163@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@ctrl/tinycolor": "^3.3.0"
+    "@ctrl/tinycolor": "^3.3.1"
   },
   "devDependencies": {
     "@types/jest": "^26.0.0",

--- a/package.json
+++ b/package.json
@@ -32,11 +32,10 @@
   "author": "afc163 <afc163@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@ctrl/tinycolor": "^3.1.6"
+    "@ctrl/tinycolor": "^3.3.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.0",
-    "@types/tinycolor2": "^1.4.1",
     "@typescript-eslint/eslint-plugin": "^4.0.0",
     "@typescript-eslint/parser": "^4.7.0",
     "coveralls": "^3.0.3",


### PR DESCRIPTION
`@ctrl/tinycolor` v3.3.0 should support ie11
Remove `@types/tinycolor2` as it is no longer needed, types are included in `@ctrl/tinycolor`


closes #71