### PR TITLE
feat: @ctrl/tinycolor treeshaking

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: [['@babel/preset-env', { targets: { node: 'current' } }], '@babel/preset-typescript'],
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
-  preset: 'ts-jest',
   collectCoverage: true,
+  // transform @ctrl/tinycolor imports from node_modules
+  transformIgnorePatterns: [],
 };

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "@ctrl/tinycolor": "^3.3.1"
   },
   "devDependencies": {
+    "@babel/preset-env": "^7.12.13",
+    "@babel/preset-typescript": "^7.12.13",
     "@types/jest": "^26.0.0",
     "@typescript-eslint/eslint-plugin": "^4.0.0",
     "@typescript-eslint/parser": "^4.7.0",
@@ -46,7 +48,6 @@
     "jest": "^26.0.1",
     "np": "^7.0.0",
     "prettier": "^2.0.0",
-    "ts-jest": "^26.0.0",
     "typescript": "^4.0.2"
   },
   "homepage": "https://github.com/ant-design/ant-design-colors#readme"

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -51,9 +51,6 @@ function toHex({ r, g, b }: RgbObject): string {
 // Amount in range [0, 1]
 // Assume color1 & color2 has no alpha, since the following src code did so.
 function mix(rgb1: RgbObject, rgb2: RgbObject, amount: number): RgbObject {
-  if (amount === void 0) {
-    amount = 50;
-  }
   const p = amount / 100;
   const rgb = {
     r: (rgb2.r - rgb1.r) * p + rgb1.r,

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -35,14 +35,14 @@ interface RgbObject {
 }
 
 // Wrapper function ported from TinyColor.prototype.toHsv
-// Keep it here because `hsv.h * 360`
+// Keep it here because of `hsv.h * 360`
 function toHsv({ r, g, b }: RgbObject): HsvObject {
   const hsv = rgbToHsv(r, g, b);
   return { h: hsv.h * 360, s: hsv.s, v: hsv.v };
 }
 
 // Wrapper function ported from TinyColor.prototype.toHexString
-// Keep it here because the prefix `#`
+// Keep it here because of the prefix `#`
 function toHex({ r, g, b }: RgbObject): string {
   return `#${rgbToHex(r, g, b, false)}`;
 }

--- a/src/tinycolor.d.ts
+++ b/src/tinycolor.d.ts
@@ -1,0 +1,14 @@
+// Declare the modules here since the library only has dts files on cjs files.
+// Maybe someone can create a PR later.
+
+declare module '@ctrl/tinycolor/dist/module/conversion' {
+  export * from '@ctrl/tinycolor/dist/conversion';
+}
+
+declare module '@ctrl/tinycolor/dist/module/format-input' {
+  export * from '@ctrl/tinycolor/dist/format-input';
+}
+
+declare module '@ctrl/tinycolor/dist/module/util' {
+  export * from '@ctrl/tinycolor/dist/util';
+}


### PR DESCRIPTION
Import functions from files instead of the index to make the bundle smaller.

I've test it with rollup, the output is treeshakable. About 20 kb less.

Before
![image](https://user-images.githubusercontent.com/18677354/107366858-94d0d300-6b19-11eb-94f4-99c572438d3f.png)


After
![image](https://user-images.githubusercontent.com/18677354/107366620-53d8be80-6b19-11eb-892d-53f3cfa11902.png)

---

Remove `ts-jest` since it won't transform modules from `node_modules` even `transfromIgnorePatterns` is set. Current config is the official way from jest to support typescript.

https://jestjs.io/docs/en/getting-started#using-typescript