### PR TITLE
fix: Use color values currently listed in ant-design docs for `gray` colors

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -1,4 +1,4 @@
-import { rgbToHsv, rgbToHex, inputToRGB, tinycolor, TinyColor } from '@ctrl/tinycolor';
+import { rgbToHsv, rgbToHex, inputToRGB } from '@ctrl/tinycolor';
 
 const hueStep = 2; // 色相阶梯
 const saturationStep = 0.16; // 饱和度阶梯，浅色部分
@@ -157,8 +157,4 @@ export default function generate(color: string, opts: Opts = {}): string[] {
     });
   }
   return patterns;
-}
-
-export function generateGrayscale(percentage: number): TinyColor {
-  return tinycolor('white').setAlpha(percentage).onBackground(tinycolor('black'));
 }

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -1,4 +1,4 @@
-import { rgbToHsv, rgbToHex, inputToRGB } from '@ctrl/tinycolor';
+import { rgbToHsv, rgbToHex, inputToRGB, tinycolor, TinyColor } from '@ctrl/tinycolor';
 
 const hueStep = 2; // 色相阶梯
 const saturationStep = 0.16; // 饱和度阶梯，浅色部分
@@ -157,4 +157,8 @@ export default function generate(color: string, opts: Opts = {}): string[] {
     });
   }
   return patterns;
+}
+
+export function generateGrayscale(percentage: number): TinyColor {
+  return tinycolor('white').setAlpha(percentage).onBackground(tinycolor('black'));
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-import generate, { generateGrayscale } from './generate';
+import tinycolor from '@ctrl/tinycolor';
+import generate from './generate';
 
 export interface PalettesProps {
   [key: string]: readonly string[] & { primary?: string };
@@ -37,9 +38,10 @@ Object.keys(presetPrimaryColors).forEach((key): void => {
 });
 
 // Per antd@4.18 neutral colors use a separate pattern
-const grayscaleGradient: number[] = [1, 0.98, 0.96, 0.94, 0.85, 0.75, 0.55, 0.35, 0.263, 0.15, 0.12, 0.08, 0];
+const black = tinycolor('black');
+const grayscaleGradient: number[] = [100, 98, 96, 94, 85, 75, 55, 35, 26.3, 15, 12, 8, 0];
 
-const grayColors = grayscaleGradient.map((percent) => `#${generateGrayscale(percent).toHex()}`);
+const grayColors = grayscaleGradient.map((brightness) => `#${black.lighten(brightness).toHex()}`);
 
 presetPalettes.grey = presetDarkPalettes.grey = grayColors;
 presetDarkPalettes.grey.primary = presetDarkPalettes.grey.primary = '#BFBFBF';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
-import generate from './generate';
+import generate, { generateGrayscale } from './generate';
 
 export interface PalettesProps {
-  [key: string]: string[] & { primary?: string };
+  [key: string]: readonly string[] & { primary?: string };
 }
 
 const presetPrimaryColors: {
@@ -19,7 +19,6 @@ const presetPrimaryColors: {
   geekblue: '#2F54EB',
   purple: '#722ED1',
   magenta: '#EB2F96',
-  grey: '#666666',
 };
 
 const presetPalettes: PalettesProps = {};
@@ -36,6 +35,14 @@ Object.keys(presetPrimaryColors).forEach((key): void => {
   });
   presetDarkPalettes[key].primary = presetDarkPalettes[key][5];
 });
+
+// Per antd@4.18 neutral colors use a separate pattern
+const grayscaleGradient: number[] = [1, 0.98, 0.96, 0.94, 0.85, 0.75, 0.55, 0.35, 0.263, 0.15, 0.12, 0.08, 0];
+
+const grayColors = grayscaleGradient.map((percent) => `#${generateGrayscale(percent).toHex()}`);
+
+presetPalettes.grey = presetDarkPalettes.grey = grayColors;
+presetDarkPalettes.grey.primary = presetDarkPalettes.grey.primary = '#BFBFBF';
 
 const red = presetPalettes.red;
 const volcano = presetPalettes.volcano;


### PR DESCRIPTION
# What & why

Calculate the list of neutral (gray) colors using a separate function so that the colors exported in this package reflect the gray colors currently shown in [ant-design's documentation (as of v4.18.4)](https://ant.design/docs/spec/colors#Neutral-Color-Palette).

Previously the shades of gray from this package are:

`#a6a6a6` `#999999` `#8c8c8c` `#808080` `#737373` `#666666` `#404040` `#1a1a1a` `#000000` `#000000`

which don't match what's provided in the docs, and are also too dark (notice how the last two are black).

With this change, the package instead exports, for `grey`:

`#ffffff` `#fafafa` `#f5f5f5` `#f0f0f0` `#d9d9d9` `#bfbfbf` `#8c8c8c` `#595959` `#434343` `#262626` `#1f1f1f` `#141414` `#000000`

which makes it possible to use this package for neutral colors while following ant design guidelines.