### PR TITLE
调整一下导入方式，解决esm引入antd的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "prettier": "^2.8.8",
     "ts-jest": "^26.5.6",
     "tsx": "^4.16.1",
-    "typescript": "^4.9.5",
+    "typescript": "~5.8.2",
     "vitest": "^1.6.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { default as generate } from './generate';
 export * from './presets'
-export * from './types'
+export type * from './types'


### PR DESCRIPTION
改动很简单：
![image](https://github.com/user-attachments/assets/3fafdfcb-47f6-484f-9766-3fe08205251e)
这个会导致esm.sh引入antd失败 https://github.com/esm-dev/esm.sh/issues/1125

因为目前构建生成会多一个无用的 `export * from "./types";`
![image](https://github.com/user-attachments/assets/00bfefcb-cbc7-4037-b6a1-8ad48350d556)

esm的issue里说这个是esbuild的支持问题。不过这个导出确实没什么用。加上`type`构建就会抹去这个导出了。

顺便，这个也会修复eslint的报错。

